### PR TITLE
Search 1508 - Media booking updates

### DIFF
--- a/get-this.rb
+++ b/get-this.rb
@@ -118,7 +118,11 @@ end
 post '/booking' do
   barcode = ''
   barcode = URI.parse(request.referrer).path.gsub('/','') if request.referrer
-  response = Option::MediaBooking.book(uniqname: session[:uniqname], barcode: barcode, booking_date: params[:date], pickup_location: params["pickup-location"])
+  begin 
+    response = Option::MediaBooking.book(uniqname: session[:uniqname], barcode: barcode, booking_date: params[:date], pickup_location: params["pickup-location"])
+  rescue
+    response = OpenStruct.new(code: 500)
+  end
   if response.code != 200
     flash[:error] = "Item was not able to be scheduled for pickup"
     redirect request.referrer

--- a/models/item.rb
+++ b/models/item.rb
@@ -4,7 +4,7 @@ class Item
   end
   def self.for(barcode, options={})
     client = options[:alma_client] || AlmaRestClient.client
-    alma_response = client.get("/items", query: {item_barcode: barcode})
+    alma_response = client.get("/items", query: {item_barcode: barcode, expand: "due_date"})
     if alma_response.code == 200
       Item.new(data: alma_response.parsed_response)
     else
@@ -34,7 +34,7 @@ class Item
     @data.dig("item_data", "barcode")
   end
   def due_date
-    @data.dig("item_data","due_date")
+    @data.dig("item_data","due_date") || ""
   end
   def mms_id
     @data.dig("bib_data","mms_id")

--- a/models/item.rb
+++ b/models/item.rb
@@ -33,6 +33,9 @@ class Item
   def barcode
     @data.dig("item_data", "barcode")
   end
+  def due_date
+    @data.dig("item_data","due_date")
+  end
   def mms_id
     @data.dig("bib_data","mms_id")
   end

--- a/models/options/media_booking.rb
+++ b/models/options/media_booking.rb
@@ -100,11 +100,10 @@ class Option
       end.flatten(1).join(", ")
     end
     def initial_unavailable_dates
-      due_date = @item.dig("item_data","due_date")
-      if due_date.empty?
+      if @item.due_date.empty?
         days = num_days_process_time - 1
       else
-        days = (Time.zone.parse(due_date).to_date - @today.to_date).to_i + num_days_process_time
+        days = (Time.zone.parse(@item.due_date).to_date - @today.to_date).to_i + num_days_process_time
       end
       (0..days).map{|x| (@today + x.day).to_date.to_s}
     end

--- a/models/options/media_booking.rb
+++ b/models/options/media_booking.rb
@@ -40,13 +40,21 @@ class Option
     end
     def booked_dates
       @data["booking_availability"]&.map do |booking|
-        head_time_counter = 0 
-        start_date = (Time.zone.parse(booking["from_time"])).to_date
-        end_date = Time.zone.parse(booking["to_time"]).to_date + num_days_tail_time.days
+        start_date = Time.zone.parse(booking["from_time"]).to_date
+        end_date = start_date
 
-        while head_time_counter < num_days_head_time + num_days_of_checkout
+        #calculate end date after booking start time
+        process_time_counter = 0
+        while process_time_counter < num_days_process_time + num_days_of_checkout
+          end_date = end_date + 1.day
+          process_time_counter = process_time_counter + 1 unless @closed_days.closed?(end_date)
+        end
+
+        #calculate start date before booking start time
+        process_time_counter = 0 
+        while process_time_counter < num_days_process_time + num_days_of_checkout
           start_date = start_date - 1.day
-          head_time_counter = head_time_counter + 1 unless @closed_days.closed?(start_date)
+          process_time_counter = process_time_counter + 1 unless @closed_days.closed?(start_date)
         end
 
         dates =  []
@@ -76,13 +84,10 @@ class Option
     end
     private
     def num_days_of_checkout
+      7
+    end
+    def num_days_process_time
       2
-    end
-    def num_days_head_time
-      3
-    end
-    def num_days_tail_time
-      3
     end
   end
 end

--- a/models/options/media_booking.rb
+++ b/models/options/media_booking.rb
@@ -24,9 +24,10 @@ class Option
       else
       end
     end
-    def initialize(data:, closed_days: ClosedDays.new)
+    def initialize(data:, closed_days: ClosedDays.new, today: Time.zone.today)
       @data = data
       @closed_days = closed_days
+      @today = today
     end
     def type
       'book-this'
@@ -62,13 +63,16 @@ class Option
       end
     end
     def unavailable_dates
-      closed = @closed_days.closed_days_between(end_date: Time.zone.today + 9.months).map do |x|
+      closed = @closed_days.closed_days_between(end_date: @today + 9.months).map do |x|
         x.to_s(:db)
       end
-      [booked_dates, closed].flatten.uniq.sort
+      [initial_unavailable_dates, booked_dates, closed].flatten.uniq.sort
     end
     def unavailable_dates_formatted
       unavailable_dates.map{|x| "\"#{x}\""}.join(", ")
+    end
+    def initial_unavailable_dates
+      [@today, @today+1.day].map{|x| x.to_date.to_s}
     end
     private
     def num_days_of_checkout

--- a/models/options/media_booking.rb
+++ b/models/options/media_booking.rb
@@ -81,7 +81,7 @@ class Option
       unavailable_dates.map{|x| "\"#{x}\""}.join(", ")
     end
     def unavailable_dates_text
-      dates = unavailable_dates.map{|x| Date.parse(x)}
+      dates = unavailable_dates.filter_map{|x| Date.parse(x) if Date.parse(x) >= @today.to_date}
       by_month = dates.chunk{|x| x.month}
       ranges = by_month.map do |m, day|
         day.chunk_while do |a, b| 

--- a/models/options/media_booking.rb
+++ b/models/options/media_booking.rb
@@ -80,6 +80,25 @@ class Option
     def unavailable_dates_formatted
       unavailable_dates.map{|x| "\"#{x}\""}.join(", ")
     end
+    def unavailable_dates_text
+      dates = unavailable_dates.map{|x| Date.parse(x)}
+      by_month = dates.chunk{|x| x.month}
+      ranges = by_month.map do |m, day|
+        day.chunk_while do |a, b| 
+          b.mday == a.mday + 1
+        end
+      end.flatten(1)
+
+      ranges.map do |big_r|
+        big_r.map do |r|
+          if r.size == 1
+            r.first.strftime("%b %-d, %Y")
+          else
+            r.first.strftime("%b %-d") + " - " + r.last.strftime("%-d, %Y")
+          end
+        end
+      end.flatten(1).join(", ")
+    end
     def initial_unavailable_dates
       due_date = @item.dig("item_data","due_date")
       if due_date.empty?

--- a/spec/fixtures/empty_booking_availability.json
+++ b/spec/fixtures/empty_booking_availability.json
@@ -1,0 +1,3 @@
+{
+  "booking_availability": null
+}

--- a/spec/fixtures/item.json
+++ b/spec/fixtures/item.json
@@ -88,6 +88,7 @@
         "enumeration_g": "",
         "enumeration_h": "",
         "fulfillment_note": "",
+        "due_date": "",
         "imprint": null,
         "internal_note_1": "",
         "internal_note_2": "",

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -28,6 +28,11 @@ describe Item do
       expect(subject.barcode).to eq("39015009714562")
     end
   end
+  context "#due_date" do
+    it "returns the duedate" do
+      expect(subject.due_date).to eq("")
+    end
+  end
   context "#mms_id" do
     it "returns the mms_id" do
       expect(subject.mms_id).to eq("990003116350106381")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,7 +3,7 @@ describe Item do
     @output = JSON.parse(fixture('item.json'))
   end
   subject do
-    stub_alma_get_request(url: "items", output:@output.to_json, query: {item_barcode: '39015009714562'} )
+    stub_alma_get_request(url: "items", output:@output.to_json, query: {item_barcode: '39015009714562', expand: "due_date"} )
     described_class.for('39015009714562')
   end
   context "#title" do
@@ -30,6 +30,11 @@ describe Item do
   end
   context "#due_date" do
     it "returns the duedate" do
+      @output["item_data"]["due_date"] = "2021-10-01T01:00:00Z"
+      expect(subject.due_date).to eq("2021-10-01T01:00:00Z")
+    end
+    it "returns empty string for nil due date" do
+      @output["item_data"].delete("due_date")
       expect(subject.due_date).to eq("")
     end
   end

--- a/spec/models/options/media_booking_spec.rb
+++ b/spec/models/options/media_booking_spec.rb
@@ -47,6 +47,13 @@ describe Option::MediaBooking do
       allow(@closed_days).to receive(:closed_days_between).and_return([Date.parse("2021-12-31"), Date.parse("2022-01-01")])
       expect(subject.unavailable_dates_text).to eq("Oct 1 - 2, 2021, Oct 17 - 31, 2021, Nov 1 - 4, 2021, Dec 31, 2021, Jan 1, 2022")
     end
+
+    it "does not display unavailable days in the past" do
+      @booking_data["booking_availability"][0]["from_time"] = "2021-10-01T16:07:00Z"
+      allow(@closed_days).to receive(:closed?).and_return(false)
+      allow(@closed_days).to receive(:closed_days_between).and_return([])
+      expect(subject.unavailable_dates_text).to eq("Oct 1 - 10, 2021")
+    end
     
   end
 

--- a/spec/models/options/media_booking_spec.rb
+++ b/spec/models/options/media_booking_spec.rb
@@ -92,7 +92,7 @@ describe Option::MediaBooking, ".book" do
       booking_start_date: "2021-10-24T15:00:00-04:00",
       booking_end_date: "2021-10-26T15:00:00-04:00",
     }.to_json
-    item_req = stub_alma_get_request(url: "items", output: fixture('item.json'), query: {item_barcode: barcode} )
+    item_req = stub_alma_get_request(url: "items", output: fixture('item.json'), query: {item_barcode: barcode, expand: "due_date"} )
     booking_req = stub_alma_post_request(url: "users/tutor/requests", input: booking_request_body, query: {item_pid: '23744541730006381'})
     described_class.book(uniqname: 'tutor', barcode: barcode, booking_date: '2021-10-24', pickup_location: 'SHAP')
     expect(item_req).to have_been_requested 

--- a/spec/models/options/media_booking_spec.rb
+++ b/spec/models/options/media_booking_spec.rb
@@ -38,6 +38,17 @@ describe Option::MediaBooking do
       expect(subject.booked_dates).to eq([])
     end
   end
+  context "#unavailable_dates_text" do
+    it "returns string of dates in desired format" do
+      initial_unavailable_dates = ["2021-10-01", "2021-10-02"]
+      october_unavailable_days=(17..31).map{|x| "2021-10-#{x}"}
+      november_unavailable_days=(1..4).map{|x| "2021-11-0#{x}"}
+      allow(@closed_days).to receive(:closed?).and_return(false)
+      allow(@closed_days).to receive(:closed_days_between).and_return([Date.parse("2021-12-31"), Date.parse("2022-01-01")])
+      expect(subject.unavailable_dates_text).to eq("Oct 1 - 2, 2021, Oct 17 - 31, 2021, Nov 1 - 4, 2021, Dec 31, 2021, Jan 1, 2022")
+    end
+    
+  end
 
   context "#unavailable_dates" do
     
@@ -48,7 +59,6 @@ describe Option::MediaBooking do
       allow(@closed_days).to receive(:closed?).and_return(false)
       allow(@closed_days).to receive(:closed_days_between).and_return([Date.parse("2021-12-31")])
       expect(subject.unavailable_dates).to eq([initial_unavailable_dates, october_unavailable_days, november_unavailable_days, "2021-12-31"].flatten)
-
     end
 
     it "for available item, return only number of processing days from today as unavailable" do

--- a/spec/models/options/media_booking_spec.rb
+++ b/spec/models/options/media_booking_spec.rb
@@ -6,7 +6,7 @@ describe Option::MediaBooking do
     @item = JSON.parse(fixture('item.json'))
   end
   subject do
-    described_class.new(booking_data: @booking_data, item: @item, closed_days: @closed_days, today: @today)
+    described_class.new(booking_data: @booking_data, item: Item.new(data: @item), closed_days: @closed_days, today: @today)
   end
   context "#booked_dates"  do
     it "returns an array of dates that includes head time of 2 days and head checkout time of 7 days" do

--- a/spec/models/options/media_booking_spec.rb
+++ b/spec/models/options/media_booking_spec.rb
@@ -9,42 +9,43 @@ describe Option::MediaBooking do
     described_class.new(data: @output, closed_days: @closed_days, today: @today)
   end
   context "#booked_dates"  do
-    it "returns an array of dates that includes head time of 5 days and head checkout time of 2 days" do
+    it "returns an array of dates that includes head time of 2 days and head checkout time of 7 days" do
       allow(@closed_days).to receive(:closed?).and_return(false)
-      new_booking_days=["2021-10-21","2021-10-22"]
-      head_days = ["2021-10-23","2021-10-24","2021-10-25"]
-      booking_days = ["2021-10-26","2021-10-27", "2021-10-28"]
-      tail_days = ["2021-10-29","2021-10-30","2021-10-31"]
+      new_booking_days=(17..23).map{|x| "2021-10-#{x}"}
+      head_days = ["2021-10-24","2021-10-25"]
+      booking_days = ["2021-10-26","2021-10-27", "2021-10-28","2021-10-29","2021-10-30","2021-10-31", "2021-11-01", "2021-11-02"]
+      tail_days = ["2021-11-03", "2021-11-04"]
       expect(subject.booked_dates).to eq([new_booking_days, head_days, booking_days, tail_days].flatten)
     end
     it "handles closed days in head time of booked items" do
       allow(@closed_days).to receive(:closed?).and_return(false)
       allow(@closed_days).to receive(:closed?).with(Date.parse("2021-10-25")).and_return(true)
       allow(@closed_days).to receive(:closed?).with(Date.parse("2021-10-24")).and_return(true)
-      new_booking_days=["2021-10-19","2021-10-20"]
-      head_days = ["2021-10-21","2021-10-22","2021-10-23"]
-      holidays = ["2021-10-24", "2021-10-25"]
-      booking_days = ["2021-10-26","2021-10-27", "2021-10-28"]
-      tail_days = ["2021-10-29","2021-10-30","2021-10-31"]
-      expect(subject.booked_dates).to eq([new_booking_days, head_days, holidays, booking_days, tail_days].flatten)
+      october_unavailable_days=(15..31).map{|x| "2021-10-#{x}"}
+      november_unavailable_days=(1..4).map{|x| "2021-11-0#{x}"}
+
+      expect(subject.booked_dates).to eq([october_unavailable_days, november_unavailable_days].flatten)
+    end
+    it "handles closed days in main time of booked items" do
+      october_unavailable_days=(17..31).map{|x| "2021-10-#{x}"}
+      november_unavailable_days=(1..5).map{|x| "2021-11-0#{x}"}
+      allow(@closed_days).to receive(:closed?).and_return(false)
+      allow(@closed_days).to receive(:closed?).with(Date.parse("2021-10-31")).and_return(true)
+      expect(subject.booked_dates).to eq([october_unavailable_days, november_unavailable_days].flatten)
     end
     it "returns empty array for not booked item" do
       @output["booking_availability"] = nil
       expect(subject.booked_dates).to eq([])
     end
-
   end
 
   context "#unavailable_dates" do
     it "returns booked_dates plus dates when the institution is closed" do
-      new_booking_days=["2021-10-21","2021-10-22"]
-      head_days = ["2021-10-23","2021-10-24","2021-10-25"]
-      booking_days = ["2021-10-26","2021-10-27", "2021-10-28"]
-      tail_days = ["2021-10-29","2021-10-30","2021-10-31"]
-      booking_unavailable = [new_booking_days,head_days,booking_days,tail_days].flatten
+      october_unavailable_days=(17..31).map{|x| "2021-10-#{x}"}
+      november_unavailable_days=(1..4).map{|x| "2021-11-0#{x}"}
       allow(@closed_days).to receive(:closed?).and_return(false)
       allow(@closed_days).to receive(:closed_days_between).and_return([Date.parse("2021-12-31")])
-      expect(subject.unavailable_dates).to eq([@initial_unavailable_dates, booking_unavailable, "2021-12-31"].flatten)
+      expect(subject.unavailable_dates).to eq([@initial_unavailable_dates, october_unavailable_days, november_unavailable_days, "2021-12-31"].flatten)
 
     end
 

--- a/spec/weblogin_spec.rb
+++ b/spec/weblogin_spec.rb
@@ -9,7 +9,7 @@ describe "requests" do
     }
     env 'rack.session', @session
   end
-  let(:stub_item){ stub_alma_get_request(url: "items", output: fixture('item.json'), query: {item_barcode: 'somebarcode'} )}
+  let(:stub_item){ stub_alma_get_request(url: "items", output: fixture('item.json'), query: {item_barcode: 'somebarcode', expand: 'due_date'} )}
   let(:stub_patron){ stub_alma_get_request(url: "users/tutor", output: fixture('mrio_user_alma.json') )}
   context "/login" do
     it "sendings off to omniauth; session has correct redirect path" do

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -30,7 +30,7 @@
   }
 
   const today = new Date()
-  const start = addDays(today, 5)
+  const start = addDays(today)
   const end = new Date(today.setMonth(today.getMonth() + 9))
 
   function isDateDisabled(date) {

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -12,6 +12,7 @@
     </select>
 
     <label for="date">Pickup date (YYYY-MM-DD)</label>
+    This item is unavailable on the following dates: <%=option.unavailable_dates_text%>
     <duet-date-picker identifier="date"></duet-date-picker>
 
     <br>

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -12,7 +12,7 @@
     </select>
 
     <label for="date">Pickup date (YYYY-MM-DD)</label>
-    This item is unavailable on the following dates: <%=option.unavailable_dates_text%>
+    <!== This item is unavailable on the following dates: <%=option.unavailable_dates_text%> !>
     <duet-date-picker identifier="date"></duet-date-picker>
 
     <br>


### PR DESCRIPTION
Changes
* Users are able to check out items two days from today.
* Backend check so users are only able to select  dates not in the unavailable list
* Added method so a text summary of unavailable dates is possible to add.