### PR TITLE
[SEARCH-1582] Display of unavailable dates in Media Booking

### DIFF
--- a/css/get-this.css
+++ b/css/get-this.css
@@ -8,6 +8,10 @@
     grid-template-columns: 2fr minmax(240px, 1fr);
     gap: 0 var(--space-xxx-large);
   }
+
+  .get-option .get-this-option-header {
+    height: 100%;
+  }
 }
 
 .strong {
@@ -47,7 +51,6 @@
   padding: var(--space-large);
   text-decoration: none;
   border-radius: var(--radius-default);
-  height: 100%;
 }
 
 .get-option .get-this-option-header + * {
@@ -62,14 +65,6 @@
 .get-option .get-this-option-header > * {
   display: inline;
 }
-
-/*
-.get-option .get-this-option-header:hover .get-option-title {
-  text-decoration-thickness: 2px;
-  text-decoration: underline;
-  text-decoration-color: var(--color-teal-400);
-}
-*/
 
 .get-url {
   text-decoration: none;

--- a/css/get-this.css
+++ b/css/get-this.css
@@ -1,9 +1,17 @@
+.get-this-layout {
+  padding-bottom: var(--viewport-margin);
+}
+
 @media (min-width: 1000px) {
   .get-this-layout {
     display: grid;
     grid-template-columns: 2fr minmax(240px, 1fr);
     gap: 0 var(--space-xxx-large);
   }
+}
+
+.strong {
+  font-weight: var(--semibold);
 }
 
 .get-this-metdata {
@@ -82,19 +90,44 @@
   Forms
 */
 
-label {
-  display: block;
-  font-weight: 600;
-  margin-bottom: var(--space-xx-small);
+form,
+form > * {
+  margin: 0;
 }
 
-button {
-  margin: 0;
+form > * + * {
+  display: block;
+  margin-top: var(--space-small);
+}
+
+label {
+  display: block;
+  font-weight: var(--semibold);
+}
+
+.message {
+  background: var(--color-neutral-100);
+  border-bottom: 1px solid var(--color-neutral-400);
+  padding: var(--space-small) var(--space-medium);
+}
+
+.message--success {
+  background: var(--color-green-100);
+  border-bottom: 1px solid var(--color-green-400);
+}
+
+.message--warning {
+  background: var(--color-maize-100);
+  border-bottom: 1px solid var(--color-maize-400);
+}
+
+.message--critical {
+  background: var(--color-pink-100);
+  border-bottom: 1px solid var(--color-pink-400);
 }
 
 input[type='text'] {
   font-size: 1rem;
-  margin: 0;
   border: solid 1px rgba(0, 0, 0, 0.5);
   box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.1);
   border-radius: 4px;
@@ -116,7 +149,6 @@ select {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  margin: 0;
 
   padding: var(--space-small) var(--space-medium);
   padding-right: var(--space-xx-large);
@@ -132,10 +164,6 @@ select {
   background-repeat: no-repeat;
   background-position-x: calc(100% - 6px);
   background-position-y: 6px;
-}
-
-form {
-  margin: 0;
 }
 
 .confirmation {

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -12,37 +12,37 @@
     </select>
 
     <label for="date">Pickup date (YYYY-MM-DD)</label>
-    <!== This item is unavailable on the following dates: <%=option.unavailable_dates_text%> !>
+    <div class="message message--warning">
+      <span class="strong">Item availability:</span> This item is unavailable on the upcoming dates: <%=option.unavailable_dates_text%>
+    </div>
     <duet-date-picker identifier="date"></duet-date-picker>
-
-    <br>
 
     <button class="button-most-important">Schedule pickup</button>
   </form>
 </section>
 
 <script>
-  const unavailableDates = [<%= option.unavailable_dates_formatted %>]
+  const unavailableDates = [<%= option.unavailable_dates_formatted %>];
 
-  function addDays(date, days) {
-    var result = new Date(date);
+  function addDays(date, days = 0) {
+    const result = new Date(date);
     result.setDate(result.getDate() + days);
     return result;
   }
 
-  const today = new Date()
-  const start = addDays(today)
-  const end = new Date(today.setMonth(today.getMonth() + 9))
+  const today = new Date();
+  const start = addDays(today);
+  const end = new Date(today.setMonth(today.getMonth() + 9));
 
   function isDateDisabled(date) {
-    const outsideRange = date < start || date > end
-    const unavailable = unavailableDates.includes(date.toISOString().slice(0,10))
+    const outsideRange = date < start || date > end;
+    const unavailable = unavailableDates.includes(date.toISOString().slice(0,10));
 
-    return outsideRange || unavailable
+    return outsideRange || unavailable;
   }
 
-  const datePicker = document.querySelector("duet-date-picker")
-  datePicker.isDateDisabled = isDateDisabled
-  datePicker.max = end.toISOString().slice(0,10)
-  datePicker.min = start.toISOString().slice(0,10)
+  const datePicker = document.querySelector('duet-date-picker');
+  datePicker.isDateDisabled = isDateDisabled;
+  datePicker.max = end.toISOString().slice(0,10);
+  datePicker.min = start.toISOString().slice(0,10);
 </script>

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -12,9 +12,11 @@
     </select>
 
     <label for="date">Pickup date (YYYY-MM-DD)</label>
-    <div class="message message--warning">
-      <span class="strong">Item availability:</span> This item is unavailable on the upcoming dates: <%=option.unavailable_dates_text%>
-    </div>
+    <% if option.unavailable_dates %>
+      <div class="message message--warning">
+        <span class="strong">Item availability:</span> This item is unavailable on the upcoming dates: <%=option.unavailable_dates_text%>
+      </div>
+    <% end %>
     <duet-date-picker identifier="date"></duet-date-picker>
 
     <button class="button-most-important">Schedule pickup</button>

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -22,9 +22,7 @@
 </section>
 
 <script>
-  const unavailableDates = [<%= option.unavailable_dates_formatted %>];
-
-  function addDays(date, days = 0) {
+  const addDays = (date, days = 0) => {
     const result = new Date(date);
     result.setDate(result.getDate() + days);
     return result;
@@ -33,16 +31,20 @@
   const today = new Date();
   const start = addDays(today);
   const end = new Date(today.setMonth(today.getMonth() + 9));
+  const unavailableDates = [<%= option.unavailable_dates_formatted %>];
 
-  function isDateDisabled(date) {
+  const changeFormat = (date) => {
+    return date.toISOString().slice(0,10);
+  }
+
+  const isDateDisabled = (date) => {
     const outsideRange = date < start || date > end;
-    const unavailable = unavailableDates.includes(date.toISOString().slice(0,10));
-
+    const unavailable = unavailableDates.includes(changeFormat(date));
     return outsideRange || unavailable;
   }
 
   const datePicker = document.querySelector('duet-date-picker');
   datePicker.isDateDisabled = isDateDisabled;
-  datePicker.max = end.toISOString().slice(0,10);
-  datePicker.min = start.toISOString().slice(0,10);
+  datePicker.max = changeFormat(end);
+  datePicker.min = changeFormat(start);
 </script>


### PR DESCRIPTION
# Overview
Get This will now display a message to users that inform them if an item is unavailable on certain days before selecting a pickup date.

This pull request resolves [SEARCH-1582](https://tools.lib.umich.edu/jira/browse/SEARCH-1582).

## Anything else?
### Styling cleanup
There were some inconsistencies in styling in Firefox, so changes have been made to fix it.

### JavaScript Errors
The `start` variable produced an error because of the lack of a `days` argument. The `addDays()` function has been updated to have a default argument. This change also now officially blocks off all days prior to today.

The code has also been cleaned up and modernized to ES6 standards.

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Get an [item](http://localhost:4567/39015083499551) and schedule a pickup.
  - Does a message appear about unavailable dates?
  - Can you select days before today?
  - Can you select days that are unavailable?
