### PR TITLE
[SEARCH-1619] Update Media Booking screen in Get This to match current design document

### DIFF
--- a/css/styles/base.css
+++ b/css/styles/base.css
@@ -46,6 +46,7 @@ main > * + * {
 @media (min-width: 1000px) {
   main {
     align-content: start;
+    align-items: flex-start;
     display: grid;
     gap: 0 var(--space-xxx-large);
     grid-template-areas:

--- a/css/styles/forms.css
+++ b/css/styles/forms.css
@@ -96,24 +96,37 @@ duet-date-picker {
   --duet-color-text: var(--color-neutral-400);
   --duet-color-text-active: white;
   --duet-font: var(--font-base-family);
-  --duet-font-bold: 600;
+  --duet-font-bold: var(--semibold);
   --duet-font-normal: 400;
-  --duet-radius: 4px;
+  --duet-radius: var(--radius-default);
   --duet-z-index: 600;
+}
+
+.duet-date__day {
+  font-weight: var(--duet-font-bold);
+}
+
+.duet-date__day.is-outside.is-disabled,
+.duet-date__day[aria-disabled='true'] {
+  background: none;
+  color: var(--color-neutral-300);
+  font-weight: var(--duet-font-normal);
+  opacity: 1;
+  text-decoration: line-through;
+  text-decoration-color: var(--color-neutral-200);
+}
+
+.duet-date__day.is-month:not([aria-disabled='true']):hover {
+  border: solid 1px var(--color-teal-400);
 }
 
 .duet-date__day:focus,
 .duet-date__select select:focus + .duet-date__select-label,
 .duet-date__next:focus,
 .duet-date__prev:focus {
-  box-shadow: 0 0 0 2px var(--color-maize-400),
+  box-shadow: 0 0 0 var(--space-xxx-small) var(--color-maize-400),
     0 0 0 3px var(--color-neutral-400);
   outline: 0;
-}
-
-.duet-date__next,
-.duet-date__prev {
-  border-radius: 4px;
 }
 
 .duet-date__day:focus {
@@ -121,13 +134,7 @@ duet-date-picker {
   color: var(--color-neutral-400);
 }
 
-.duet-date__day.is-outside.is-disabled,
-.duet-date__day[aria-disabled='true'] {
-  background: none;
-  color: var(--color-neutral-300);
-  opacity: 1;
-}
-
-.duet-date__day.is-month:not([aria-disabled='true']):hover {
-  border: solid 1px var(--color-teal-400);
+.duet-date__next,
+.duet-date__prev {
+  border-radius: var(--duet-radius);
 }

--- a/css/styles/get-option.css
+++ b/css/styles/get-option.css
@@ -8,6 +8,7 @@
  * Table of Contents
  * -----------------
  * 1.0 - Container
+ * 2.0 - Content
  */
 
 
@@ -22,4 +23,18 @@
   box-shadow: 0 var(--space-xxx-small) var(--space-x-small) 0 rgba(16, 102, 132, 0.5);
   grid-area: content;
   padding: var(--space-large);
+}
+
+
+
+/*********************/
+/*** 2.0 - Content ***/
+/*********************/
+
+.get-option h2 {
+  margin-bottom: 0;
+}
+
+.get-option h2 + * {
+  margin-top: 0;
 }

--- a/css/styles/sidebar.css
+++ b/css/styles/sidebar.css
@@ -72,3 +72,9 @@ aside ul.contact li {
 aside ul.contact li + li {
   margin-top: var(--space-medium);
 }
+
+aside ul.contact li svg {
+  fill: var(--color-teal-400);
+  height: auto;
+  width: 1em;
+}

--- a/css/styles/sidebar.css
+++ b/css/styles/sidebar.css
@@ -9,6 +9,8 @@
  * -----------------
  * 1.0 - Container
  * 2.0 - Content
+ *   2.1 - Item Details
+ *   2.2 - Service Info
  */
 
 
@@ -23,17 +25,50 @@ aside {
   top: var(--space-x-large);
 }
 
+aside > * + * {
+  margin-top: var(--space-x-large);
+}
+
 
 
 /*********************/
 /*** 2.0 - Content ***/
 /*********************/
 
-aside > dl.record {
+aside .subtle-heading,
+aside .subtle-heading + h3 {
+  margin-bottom: 0;
+}
+
+aside .subtle-heading + * {
+  margin-top: 0;
+}
+
+/*** 2.1 - Item Details ***/
+
+aside dl.record {
   grid-template-columns: minmax(max-content, auto) 1fr;
   width: 100%;
 }
 
-aside > dl.record > dt {
+aside dl.record > dt {
   padding-right: var(--space-x-large);
+}
+
+/*** 2.2 - Service Info ***/
+
+aside ul.contact {
+  list-style: none;
+  padding: 0;
+}
+
+aside ul.contact li {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-x-small);
+}
+
+aside ul.contact li + li {
+  margin-top: var(--space-medium);
 }

--- a/css/styles/sidebar.css
+++ b/css/styles/sidebar.css
@@ -47,7 +47,7 @@ aside .subtle-heading + * {
 /*** 2.1 - Item Details ***/
 
 aside dl.record {
-  grid-template-columns: minmax(max-content, auto) 1fr;
+  grid-template-columns: minmax(min-content, max-content) auto;
   width: 100%;
 }
 

--- a/css/styles/typography.css
+++ b/css/styles/typography.css
@@ -9,6 +9,7 @@
  * 1.0 - Headings
  * 2.0 - Heading Variants
  * 3.0 - Font Weights
+ * 4.0 - Font Sizes
  */
 
 
@@ -40,4 +41,15 @@ h1 {
 
 .strong {
   font-weight: var(--semibold);
+}
+
+
+
+/**************************/
+/*** 4.0 - Font Sizes ***/
+/**************************/
+
+small {
+  color: var(--color-blue-300);
+  font-size: 0.875rem;
 }

--- a/get-this.rb
+++ b/get-this.rb
@@ -124,7 +124,7 @@ post '/booking' do
     response = OpenStruct.new(code: 500)
   end
   if response.code != 200
-    flash[:error] = "Item was not able to be scheduled for pickup"
+    flash[:critical] = "Item was not able to be scheduled for pickup"
     redirect request.referrer
   else
     data = response.parsed_response

--- a/models/item.rb
+++ b/models/item.rb
@@ -18,6 +18,16 @@ class Item
   def library
     @data.dig("item_data", "library", "desc")
   end
+  def location
+    @data.dig("item_data", "location", "desc")
+  end
+  def shelving_location
+    item_location = library
+    if location != "NONE"
+      item_location += " #{location}"
+    end
+    item_location
+  end
   def library_code
     @data.dig("item_data", "library", "value")
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -18,6 +18,18 @@ describe Item do
     end
   end
 
+  context "#location" do
+    it "returns location within the library" do
+      expect(subject.location).to eq("NONE")
+    end
+  end
+
+  context "#shelving_location" do
+    it "returns shelving location" do
+      expect(subject.shelving_location).to eq("Music")
+    end
+  end
+
   context "#call_number" do
     it "returns the call number" do
       expect(subject.call_number).to eq("ML760 .P18")

--- a/views/index.erb
+++ b/views/index.erb
@@ -17,10 +17,14 @@
   <section class="container">
     <h2 class="subtle-heading">Item Details</h2>
     <dl class="record">
-      <dt>Title</dt><dd><%=item.title%></dd>
-      <!--<dt>Location</dt><dd><%=item.library%></a></dd>-->
-      <dt>Call number</dt><dd><%=item.call_number%></dd>
-      <dt>Barcode</dt><dd><%=item.barcode%></dd>
+      <dt>Title</dt>
+      <dd><%=item.title%></dd>
+      <dt>Shelving location</dt>
+      <dd><%=item.shelving_location%></dd>
+      <dt>Call number</dt>
+      <dd><%=item.call_number%></dd>
+      <dt>Barcode</dt>
+      <dd><%=item.barcode%></dd>
     </dl>
     <a href=<%=item.catalog_url%>>View item record</a>
   </section>

--- a/views/index.erb
+++ b/views/index.erb
@@ -8,21 +8,44 @@
 <% options.each do |option| %>
   <% if option.type == "book-this" %>
     <%= erb :"options/book-this", locals: {option: option} %> 
-  <%else %>
+  <% else %>
     "Not available." 
-  <%end %>
+  <% end %>
 <% end %>
 
-<aside class="container">
-  <h2 class="subtle-heading">Item details</h2>
-  <dl class="record">
-    <dt>Title</dt><dd><%=item.title%></dd>
-    <!--<dt>Location</dt><dd><%=item.library%></a></dd>-->
-    <dt>Call number</dt><dd><%=item.call_number%></dd>
-    <dt>Barcode</dt><dd><%=item.barcode%></dd>
-  </dl>
+<aside>
+  <section class="container">
+    <h2 class="subtle-heading">Item Details</h2>
+    <dl class="record">
+      <dt>Title</dt><dd><%=item.title%></dd>
+      <!--<dt>Location</dt><dd><%=item.library%></a></dd>-->
+      <dt>Call number</dt><dd><%=item.call_number%></dd>
+      <dt>Barcode</dt><dd><%=item.barcode%></dd>
+    </dl>
+    <a href=<%=item.catalog_url%>>View item record</a>
+  </section>
 
-  <a href=<%=item.catalog_url%>>View item record</a>
+  <section class="container">
+    <h2 class="subtle-heading">Service Info</h2>
+    <h3>Askwith Media Library</h3>
+    <a href="https://www.lib.umich.edu/locations-and-hours/askwith-media-library">Link to location page</a>
+    <ul class="contact">
+      <li>
+        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" width="16" height="16" fill="var(--color-teal-400)" viewBox="0 0 24 24">
+          <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
+        </svg>
+        <span>Phone:</span>
+        <a href="tel:734-764-5360">734-764-5360</a>
+      </li>
+      <li>
+        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" width="16" height="16" fill="var(--color-teal-400)" viewBox="0 0 24 24">
+          <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
+        </svg>
+        <span>Email:</span>
+        <a href="mailto:askwithmedia@umich.edu">askwithmedia@umich.edu</a>
+      </li>
+    </ul>
+  </section>
 </aside>
 
 <% if dev_login? %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -31,14 +31,14 @@
     <a href="https://www.lib.umich.edu/locations-and-hours/askwith-media-library">Link to location page</a>
     <ul class="contact">
       <li>
-        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" width="16" height="16" fill="var(--color-teal-400)" viewBox="0 0 24 24">
+        <svg focusable="false" role="presentation" viewBox="0 0 24 24">
           <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
         </svg>
         <span>Phone:</span>
         <a href="tel:734-764-5360">734-764-5360</a>
       </li>
       <li>
-        <svg xmlns="http://www.w3.org/2000/svg" focusable="false" width="16" height="16" fill="var(--color-teal-400)" viewBox="0 0 24 24">
+        <svg focusable="false" role="presentation" viewBox="0 0 24 24">
           <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
         </svg>
         <span>Email:</span>

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -13,6 +13,7 @@
     <% end %>
     <duet-date-picker identifier="date"></duet-date-picker>
     <small>*Dates unavailable for pickup are displayed gray with a strikethrough mark.</small>
+
     <button class="button-most-important">Schedule pickup</button>
   </form>
 </section>

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -1,6 +1,6 @@
 <section class="get-option container">
   <h2><%=option.title %></h2>
-  <p><%=option.subtitle %></p>
+  <p class="strong"><%=option.subtitle %></p>
 
   <form method="post" action="/booking">
     <label for="pickup-location">Pickup location</label>
@@ -9,10 +9,10 @@
     <label for="date">Pickup date (YYYY-MM-DD)</label>
     <small>Contact Askwith Media Library at askwithmedia@umich.edu or 734-764-5360 if you have questions or want to pick up an item in fewer than three days. Loans are typically for 7 days.</small>
     <% if !option.unavailable_dates.empty? %>
-      <%= erb :'components/message', :locals => { message: '<span class="strong">Item availability:</span> This item is unavailable on the upcoming dates: ' + option.unavailable_dates_text, kind: 'warning' } %>
+      <%= erb :'components/message', :locals => { message: '<span class="strong">Item availability:</span> This item is unavailable for pickup on these upcoming dates: ' + option.unavailable_dates_text, kind: 'warning' } %>
     <% end %>
     <duet-date-picker identifier="date"></duet-date-picker>
-
+    <small>*Dates unavailable for pickup are displayed gray with a strikethrough mark.</small>
     <button class="button-most-important">Schedule pickup</button>
   </form>
 </section>

--- a/views/options/book-this.erb
+++ b/views/options/book-this.erb
@@ -7,6 +7,7 @@
     <%= erb :"components/dropdown", :locals => { id: "pickup-location", options: option.pickup_locations, value: "code", label: "display" } %>
 
     <label for="date">Pickup date (YYYY-MM-DD)</label>
+    <small>Contact Askwith Media Library at askwithmedia@umich.edu or 734-764-5360 if you have questions or want to pick up an item in fewer than three days. Loans are typically for 7 days.</small>
     <% if !option.unavailable_dates.empty? %>
       <%= erb :'components/message', :locals => { message: '<span class="strong">Item availability:</span> This item is unavailable on the upcoming dates: ' + option.unavailable_dates_text, kind: 'warning' } %>
     <% end %>


### PR DESCRIPTION
# Overview
The [Figma design](https://www.figma.com/file/e5U4O9eIuNxVOYGP5SnbZX/?node-id=0%3A1) has been updated, and so the changes needed to be made accordingly.

This pull request closes [SEARCH-1619](https://tools.lib.umich.edu/jira/browse/SEARCH-1619).

## Anything else?
### Duet Date Picker
In the design, the page is supposed to display two calendars of the current month, and the next month. However, [Duet Date Picker](https://www.duetds.com/components/date-picker/) does not allow the option to display just the calendar, let alone multiple. A custom date picker would need to be developed in order to make this possible.

### Status and Format
`Status` and `Format` were supposed to be added under `Item Details`, but the received data makes the display options complicated. A future discussion needs to be had.

## Testing
List instructions on how to test the pull request. Some examples:

- Run the tests to make sure they pass (`docker-compose run web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- [View an item](http://localhost:4567/39015051081035).
  - Does `Shelving location` appear under `Item Details` in the sidebar?
  - Does `Service Info` appear in the sidebar?
  - Is there a description under `Pickup date (YYYY-MM-DD)` about contacting `Askwith Media Library`?
  - Is there disclaimer about how disabled dates are styled?
  - Are the disabled and available dates in the Duet Date Picker more obvious in styling?
