### PR TITLE
Libsearch 745 monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,8 @@ RUN groupadd -g ${GID} -o ${UNAME}
 RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
 RUN mkdir -p /gems && chown ${UID}:${GID} /gems
 
-
-COPY --chown=${UID}:${GID} Gemfile* /app/
 USER $UNAME
 
 ENV BUNDLE_PATH /gems
 
 WORKDIR /app
-
-CMD ["bundle", "exec", "ruby", "get-this.rb", "-o", "0.0.0.0"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -39,4 +39,4 @@ RUN npm ci
 RUN npm run build
 RUN cp js/* public/bundles/
 
-CMD ["bundle", "exec", "ruby", "get-this.rb", "-o", "0.0.0.0"]
+CMD ["bundle", "exec", "rackup", "-p", "4567", "--host", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem "sinatra"
 gem "httparty"
 gem "puma"
+gem "yabeda-puma-plugin"
+gem "yabeda-prometheus"
 gem "activesupport" # in here because of timezone support
 gem "omniauth"
 gem "omniauth_openid_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    anyway_config (2.3.0)
+      ruby-next-core (>= 0.14.0)
     ast (2.4.2)
     attr_required (1.0.1)
     bindata (2.4.10)
@@ -33,6 +35,7 @@ GEM
     diff-lcs (1.5.0)
     digest (3.1.0)
     docile (1.4.0)
+    dry-initializer (3.1.1)
     ffi (1.15.5)
     hashdiff (1.0.1)
     hashie (5.0.0)
@@ -42,6 +45,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.2)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -89,6 +93,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    prometheus-client (2.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -142,6 +147,7 @@ GEM
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
+    ruby-next-core (0.15.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     simplecov (0.21.2)
@@ -188,6 +194,18 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    yabeda (0.11.0)
+      anyway_config (>= 1.0, < 3)
+      concurrent-ruby
+      dry-initializer
+    yabeda-prometheus (0.8.0)
+      prometheus-client (>= 0.10, < 3.0)
+      rack
+      yabeda (~> 0.10)
+    yabeda-puma-plugin (0.6.0)
+      json
+      puma
+      yabeda (~> 0.5)
 
 PLATFORMS
   x86_64-linux
@@ -212,6 +230,8 @@ DEPENDENCIES
   sinatra-flash
   standard
   webmock
+  yabeda-prometheus
+  yabeda-puma-plugin
 
 BUNDLED WITH
    2.3.14

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,10 @@
 require "./get-this"
 require "yabeda/prometheus"
+require "prometheus/middleware/collector"
+
 Yabeda.configure!
+
+use Rack::Deflater
+use Prometheus::Middleware::Collector
 
 run Sinatra::Application

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,5 @@
+require "./get-this"
+require "yabeda/prometheus"
+Yabeda.configure!
+
+run Sinatra::Application

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,4 @@
+require "prometheus/client"
+activate_control_app
+plugin :yabeda
+plugin :yabeda_prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,21 @@ services:
     build: .
     ports:
       - "4567:4567"
+      - "9394:9394"
     volumes:
       - .:/app
       - gem_cache:/gems
     env_file:
       - .env
       - .env-dev-values
-    command: bundle exec ruby get-this.rb  -o 0.0.0.0
+    command:
+      - bundle 
+      - exec 
+      - rackup 
+      - -p
+      - "4567"
+      - --host
+      - 0.0.0.0
 
   css:
     build: .

--- a/get-this.rb
+++ b/get-this.rb
@@ -64,7 +64,7 @@ end
 
 before do
   Time.zone = "Eastern Time (US & Canada)"
-  pass if ["auth", "session_switcher", "logout", "login"].include? request.path_info.split("/")[1]
+  pass if ["auth", "session_switcher", "logout", "login", "-"].include? request.path_info.split("/")[1]
 
   if dev_login?
     session[:uniqname] = "mlibrary.acct.testing1@gmail.com" unless session[:uniqname]
@@ -132,4 +132,7 @@ post "/booking" do
     flash[:success] = "Your pickup of <strong>#{title}</strong> has been scheduled for <strong>#{pickup_date}</strong> at <strong>#{pickup_location}</strong>"
     redirect "/confirmation"
   end
+end
+get "/-/live" do
+  200
 end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -25,7 +25,7 @@ describe "requests" do
     it "works even for a not-logged-in user" do
       @session[:authenticated] = false
       env "rack.session", @session
-      get "/-/live" 
+      get "/-/live"
       expect(last_response.status).to eq(200)
     end
   end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -21,4 +21,12 @@ describe "requests" do
       expect(last_response.body).to include("Go to")
     end
   end
+  context "/-/live" do
+    it "works even for a not-logged-in user" do
+      @session[:authenticated] = false
+      env "rack.session", @session
+      get "/-/live" 
+      expect(last_response.status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
# Overview
This adds a `/-/live` route for kubernetes to use as a liveness check
It also adds puma monitoring with  yabeda and tack monitoring with the prometheus middleware collect. Both export to port :9394/metrics

This PR is for Jira ticket [LIBSEARCH-747](https://mlit.atlassian.net/browse/LIBSEARCH-747)
