### PR TITLE
[DS-120] Update properties to jsDelivr

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/bundles/get-this.css">
 
     <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js"></script>
-  
+    <script nomodule src="https://cdn.jsdelivr.net/npm/@umich-lib/components@1.1.0/dist/umich-lib/umich-lib.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/duet.esm.js"></script>
     <script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/duet.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/themes/default.css" />

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -6,11 +6,10 @@
     <title>Get This <% if defined?(item) %> "<%= item.title %>" <% end %>| University of Michigan Library</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
-    <link href="https://unpkg.com/@umich-lib/web@1/umich-lib.css" rel="stylesheet"/>
+    <link href="https://cdn.jsdelivr.net/npm/@umich-lib/web@1/umich-lib.css" rel="stylesheet"/>
     <link rel="stylesheet" href="/bundles/get-this.css">
 
-    <script type="module" src="https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js"></script>
-    <script nomodule src="https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js"></script>
   
     <script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/duet.esm.js"></script>
     <script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/duet.js"></script>


### PR DESCRIPTION
# Overview
Design System was using `unpkg` for their CDN, but has since been unsupported. They are now switching to `jsDelivr`.

This pull request updates the new CDN.

## `nomodule`
`https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.js` never existed. `web@` has been replaced with `components@`.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check the website and see if anything looks broken.
