### PR TITLE
LIBSEARCH-866 Login problems

### DIFF
--- a/get-this.rb
+++ b/get-this.rb
@@ -62,7 +62,7 @@ end
 
 before do
   Time.zone = "Eastern Time (US & Canada)"
-  pass if ["auth", "session_switcher", "logout", "login", "-"].include? request.path_info.split("/")[1]
+  pass if ["auth", "session_switcher", "logout", "login", "-", "favicon.svg"].include? request.path_info.split("/")[1]
 
   if dev_login?
     session[:uniqname] = "mlibrary.acct.testing1@gmail.com" unless session[:uniqname]


### PR DESCRIPTION
# Overview
Users are having problems with authenticated to `get-this` for media booking. 

One problem is after authenticated they are redirected to the favicon.svg instead of to the item they were looking at. 

This pull request resolves LIBSEARCH-866](https://mlit.atlassian.net/browse/LIBSEARCH-866).
