### PR TITLE
March 2024 dependency updates.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cssnano": "^6.0.3",
-        "postcss": "^8.4.33",
+        "cssnano": "^6.0.5",
+        "postcss": "^8.4.35",
         "postcss-cli": "^11.0.0",
-        "postcss-import": "^16.0.0"
+        "postcss-import": "^16.0.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz",
-      "integrity": "sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
-      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
       "dev": true,
       "funding": [
         {
@@ -155,8 +155,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001580",
-        "electron-to-chromium": "^1.4.648",
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
         "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001584",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001584.tgz",
-      "integrity": "sha512-LOz7CCQ9M1G7OjJOF9/mzmqmj3jE/7VOmrfw6Mgs0E8cjOsbRXQJHsPBfmBOXDskXKrHLyyW3n7kpDW/4BsfpQ==",
+      "version": "1.0.30001593",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz",
+      "integrity": "sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==",
       "dev": true,
       "funding": [
         {
@@ -200,16 +200,10 @@
       ]
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -221,6 +215,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -339,13 +336,13 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.3.tgz",
-      "integrity": "sha512-MRq4CIj8pnyZpcI2qs6wswoYoDD1t0aL28n+41c1Ukcpm56m1h6mCexIHBGjfZfnTqtGSSCP4/fB1ovxgjBOiw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.5.tgz",
+      "integrity": "sha512-tpTp/ukgrElwu3ESFY4IvWnGn8eTt8cJhC2aAbtA3lvUlxp6t6UPv8YCLjNnEGiFreT1O0LiOM1U3QyTBVFl2A==",
       "dev": true,
       "dependencies": {
-        "cssnano-preset-default": "^6.0.3",
-        "lilconfig": "^3.0.0"
+        "cssnano-preset-default": "^6.0.5",
+        "lilconfig": "^3.1.1"
       },
       "engines": {
         "node": "^14 || ^16 || >=18.0"
@@ -359,25 +356,25 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.3.tgz",
-      "integrity": "sha512-4y3H370aZCkT9Ev8P4SO4bZbt+AExeKhh8wTbms/X7OLDo5E7AYUUy6YPxa/uF5Grf+AJwNcCnxKhZynJ6luBA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.5.tgz",
+      "integrity": "sha512-M+qRDEr5QZrfNl0B2ySdbTLGyNb8kBcSjuwR7WBamYBOEREH9t2efnB/nblekqhdGLZdkf4oZNetykG2JWRdZQ==",
       "dev": true,
       "dependencies": {
         "css-declaration-sorter": "^7.1.1",
         "cssnano-utils": "^4.0.1",
         "postcss-calc": "^9.0.1",
-        "postcss-colormin": "^6.0.2",
-        "postcss-convert-values": "^6.0.2",
+        "postcss-colormin": "^6.0.3",
+        "postcss-convert-values": "^6.0.4",
         "postcss-discard-comments": "^6.0.1",
-        "postcss-discard-duplicates": "^6.0.1",
-        "postcss-discard-empty": "^6.0.1",
+        "postcss-discard-duplicates": "^6.0.2",
+        "postcss-discard-empty": "^6.0.2",
         "postcss-discard-overridden": "^6.0.1",
-        "postcss-merge-longhand": "^6.0.2",
-        "postcss-merge-rules": "^6.0.3",
-        "postcss-minify-font-values": "^6.0.1",
-        "postcss-minify-gradients": "^6.0.1",
-        "postcss-minify-params": "^6.0.2",
+        "postcss-merge-longhand": "^6.0.3",
+        "postcss-merge-rules": "^6.0.4",
+        "postcss-minify-font-values": "^6.0.2",
+        "postcss-minify-gradients": "^6.0.2",
+        "postcss-minify-params": "^6.0.3",
         "postcss-minify-selectors": "^6.0.2",
         "postcss-normalize-charset": "^6.0.1",
         "postcss-normalize-display-values": "^6.0.1",
@@ -385,11 +382,11 @@
         "postcss-normalize-repeat-style": "^6.0.1",
         "postcss-normalize-string": "^6.0.1",
         "postcss-normalize-timing-functions": "^6.0.1",
-        "postcss-normalize-unicode": "^6.0.2",
+        "postcss-normalize-unicode": "^6.0.3",
         "postcss-normalize-url": "^6.0.1",
         "postcss-normalize-whitespace": "^6.0.1",
         "postcss-ordered-values": "^6.0.1",
-        "postcss-reduce-initial": "^6.0.2",
+        "postcss-reduce-initial": "^6.0.3",
         "postcss-reduce-transforms": "^6.0.1",
         "postcss-svgo": "^6.0.2",
         "postcss-unique-selectors": "^6.0.2"
@@ -511,9 +508,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.656",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.656.tgz",
-      "integrity": "sha512-9AQB5eFTHyR3Gvt2t/NwR0le2jBSUNwCnMbUCejFWHD+so4tH40/dRLgoE+jxlPeWS43XJewyvCv+I8LPMl49Q==",
+      "version": "1.4.690",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.690.tgz",
+      "integrity": "sha512-+2OAGjUx68xElQhydpcbqH50hE8Vs2K6TkAeLhICYfndb67CVH0UsZaijmRUE3rHlIxU1u0jxwhgVe6fK3YANA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -535,9 +532,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -560,9 +557,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
-      "integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -651,12 +648,12 @@
       }
     },
     "node_modules/globby": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.0.tgz",
-      "integrity": "sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+      "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
       "dev": true,
       "dependencies": {
-        "@sindresorhus/merge-streams": "^1.0.0",
+        "@sindresorhus/merge-streams": "^2.1.0",
         "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
         "path-type": "^5.0.0",
@@ -677,9 +674,9 @@
       "dev": true
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -773,12 +770,15 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
+      "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
       "dev": true,
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lodash.memoize": {
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.33",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dev": true,
       "funding": [
         {
@@ -985,14 +985,14 @@
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.2.tgz",
-      "integrity": "sha512-TXKOxs9LWcdYo5cgmcSHPkyrLAh86hX1ijmyy6J8SbOhyv6ua053M3ZAM/0j44UsnQNIWdl8gb5L7xX2htKeLw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.3.tgz",
+      "integrity": "sha512-ECpkS+UZRyAtu/kjive2/1mihP+GNtgC8kcdU8ueWZi1ZVxMNnRziCLdhrWECJhEtSWijfX2Cl9XTTCK/hjGaA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0",
-        "colord": "^2.9.1",
+        "colord": "^2.9.3",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -1003,12 +1003,12 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.2.tgz",
-      "integrity": "sha512-aeBmaTnGQ+NUSVQT8aY0sKyAD/BaLJenEKZ03YK0JnDE1w1Rr8XShoxdal2V2H26xTJKr3v5haByOhJuyT4UYw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.4.tgz",
+      "integrity": "sha512-YT2yrGzPXoQD3YeA2kBo/696qNwn7vI+15AOS2puXWEvSWqdCqlOyDWRy5GNnOc9ACRGOkuQ4ESQEqPJBWt/GA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.23.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -1031,9 +1031,9 @@
       }
     },
     "node_modules/postcss-discard-duplicates": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.1.tgz",
-      "integrity": "sha512-1hvUs76HLYR8zkScbwyJ8oJEugfPV+WchpnA+26fpJ7Smzs51CzGBHC32RS03psuX/2l0l0UKh2StzNxOrKCYg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.2.tgz",
+      "integrity": "sha512-U2rsj4w6pAGROCCcD13LP2eBIi1whUsXs4kgE6xkIuGfkbxCBSKhkCTWyowFd66WdVlLv0uM1euJKIgmdmZObg==",
       "dev": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
@@ -1043,9 +1043,9 @@
       }
     },
     "node_modules/postcss-discard-empty": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.1.tgz",
-      "integrity": "sha512-yitcmKwmVWtNsrrRqGJ7/C0YRy53i0mjexBDQ9zYxDwTWVBgbU4+C9jIZLmQlTDT9zhml+u0OMFJh8+31krmOg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.2.tgz",
+      "integrity": "sha512-rj6pVC2dVCJrP0Y2RkYTQEbYaCf4HEm+R/2StQgJqGHxAa3+KcYslNQhcRqjLHtl/4wpzipJluaJLqBj6d5eDQ==",
       "dev": true,
       "engines": {
         "node": "^14 || ^16 || >=18.0"
@@ -1067,9 +1067,9 @@
       }
     },
     "node_modules/postcss-import": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.0.0.tgz",
-      "integrity": "sha512-e77lhVvrD1I2y7dYmBv0k9ULTdArgEYZt97T4w6sFIU5uxIHvDFQlKgUUyY7v7Barj0Yf/zm5A4OquZN7jKm5Q==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.0.1.tgz",
+      "integrity": "sha512-i2Pci0310NaLHr/5JUFSw1j/8hf1CzwMY13g6ZDxgOavmRHQi2ba3PmUHoihO+sjaum+KmCNzskNsw7JDrg03g==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -1084,9 +1084,9 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.0.2.tgz",
-      "integrity": "sha512-Q8QR3FYbqOKa0bnC1UQ2bFq9/ulHX5Bi34muzitMr8aDtUelO5xKeJEYC/5smE0jNE9zdB/NBnOwXKexELbRlw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.0.3.tgz",
+      "integrity": "sha512-90pBBI5apUVruIEdCxZic93Wm+i9fTrp7TXbgdUCH+/L+2WnfpITSpq5dFU/IPvbv7aNiMlQISpUkAm3fEcvgQ==",
       "dev": true,
       "funding": [
         {
@@ -1119,13 +1119,13 @@
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.2.tgz",
-      "integrity": "sha512-+yfVB7gEM8SrCo9w2lCApKIEzrTKl5yS1F4yGhV3kSim6JzbfLGJyhR1B6X+6vOT0U33Mgx7iv4X9MVWuaSAfw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.3.tgz",
+      "integrity": "sha512-kF/y3DU8CRt+SX3tP/aG+2gkZI2Z7OXDsPU7FgxIJmuyhQQ1EHceIYcsp/alvzCm2P4c37Sfdu8nNrHc+YeyLg==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^6.0.2"
+        "stylehacks": "^6.0.3"
       },
       "engines": {
         "node": "^14 || ^16 || >=18.0"
@@ -1135,12 +1135,12 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.3.tgz",
-      "integrity": "sha512-yfkDqSHGohy8sGYIJwBmIGDv4K4/WrJPX355XrxQb/CSsT4Kc/RxDi6akqn5s9bap85AWgv21ArcUWwWdGNSHA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.4.tgz",
+      "integrity": "sha512-97iF3UJ5v8N1BWy38y+0l+Z8o5/9uGlEgtWic2PJPzoRrLB6Gxg8TVG93O0EK52jcLeMsywre26AUlX1YAYeHA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^4.0.1",
         "postcss-selector-parser": "^6.0.15"
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/postcss-minify-font-values": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.1.tgz",
-      "integrity": "sha512-tIwmF1zUPoN6xOtA/2FgVk1ZKrLcCvE0dpZLtzyyte0j9zUeB8RTbCqrHZGjJlxOvNWKMYtunLrrl7HPOiR46w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.2.tgz",
+      "integrity": "sha512-IedzbVMoX0a7VZWjSYr5qJ6C37rws8kl8diPBeMZLJfWKkgXuMFY5R/OxPegn/q9tK9ztd0XRH3aR0u2t+A7uQ==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -1168,12 +1168,12 @@
       }
     },
     "node_modules/postcss-minify-gradients": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.1.tgz",
-      "integrity": "sha512-M1RJWVjd6IOLPl1hYiOd5HQHgpp6cvJVLrieQYS9y07Yo8itAr6jaekzJphaJFR0tcg4kRewCk3kna9uHBxn/w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.2.tgz",
+      "integrity": "sha512-vP5mF7iI6/5fcpv+rSfwWQekOE+8I1i7/7RjZPGuIjj6eUaZVeG4XZYZrroFuw1WQd51u2V32wyQFZ+oYdE7CA==",
       "dev": true,
       "dependencies": {
-        "colord": "^2.9.1",
+        "colord": "^2.9.3",
         "cssnano-utils": "^4.0.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -1185,12 +1185,12 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.2.tgz",
-      "integrity": "sha512-zwQtbrPEBDj+ApELZ6QylLf2/c5zmASoOuA4DzolyVGdV38iR2I5QRMsZcHkcdkZzxpN8RS4cN7LPskOkTwTZw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.3.tgz",
+      "integrity": "sha512-j4S74d3AAeCK5eGdQndXSrkxusV2ekOxbXGnlnZthMyZBBvSDiU34CihTASbJxuVB3bugudmwolS7+Dgs5OyOQ==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.23.0",
         "cssnano-utils": "^4.0.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -1304,12 +1304,12 @@
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.2.tgz",
-      "integrity": "sha512-Ff2VdAYCTGyMUwpevTZPZ4w0+mPjbZzLLyoLh/RMpqUqeQKZ+xMm31hkxBavDcGKcxm6ACzGk0nBfZ8LZkStKA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.3.tgz",
+      "integrity": "sha512-T2Bb3gXz0ASgc3ori2dzjv6j/P2IantreaC6fT8tWjqYUiqMAh5jGIkdPwEV2FaucjQlCLeFJDJh2BeSugE1ig==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.23.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -1366,12 +1366,12 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.2.tgz",
-      "integrity": "sha512-YGKalhNlCLcjcLvjU5nF8FyeCTkCO5UtvJEt0hrPZVCTtRLSOH4z00T1UntQPj4dUmIYZgMj8qK77JbSX95hSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.3.tgz",
+      "integrity": "sha512-w4QIR9pEa1N4xMx3k30T1vLZl6udVK2RmNqrDXhBXX9L0mBj2a8ADs8zkbaEH7eUy1m30Wyr5EBgHN31Yq1JvA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
@@ -1629,12 +1629,12 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.2.tgz",
-      "integrity": "sha512-00zvJGnCu64EpMjX8b5iCZ3us2Ptyw8+toEkb92VdmkEaRaSGBNKAoK6aWZckhXxmQP8zWiTaFaiMGIU8Ve8sg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.3.tgz",
+      "integrity": "sha512-KzBqjnqktc8/I0ERCb+lGq06giF/JxDbw2r9kEVhen9noHeIDRtMWUp9r62sOk+/2bbX6sFG1GhsS7ToXG0PEg==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.23.0",
         "postcss-selector-parser": "^6.0.15"
       },
       "engines": {
@@ -1783,10 +1783,13 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.0.tgz",
+      "integrity": "sha512-j9iR8g+/t0lArF4V6NE/QCfT+CO7iLqrXAHZbJdo+LfjqP1vR8Fg5bSiaq6Q2lOD1AUEVrEVIgABvBFYojJVYQ==",
       "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "homepage": "https://github.com/mlibrary/get-this#readme",
   "devDependencies": {
-    "cssnano": "^6.0.3",
-    "postcss": "^8.4.33",
+    "cssnano": "^6.0.5",
+    "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",
-    "postcss-import": "^16.0.0"
+    "postcss-import": "^16.0.1"
   }
 }


### PR DESCRIPTION
# Overview
Monthly dependency update to help maintain Get This.

## NPM
These dependencies have been updated to their latest versions:
- `cssnano`
- `postcss`
- `postcss-import`

## Testing
- Install the updated packages (`docker-compose run --rm web npm install`).
- Make a CSS change, and build the styles (`docker-compose run --rm web npm run build`).
- Start [the site](http://localhost:4567) to see if your change was made, and everything still works (`docker-compose up`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
  