### PR TITLE
Update Design system version; remove image scanning; update dependencies

### DIFF
--- a/.github/workflows/build-deploy-on-release.yaml
+++ b/.github/workflows/build-deploy-on-release.yaml
@@ -14,20 +14,20 @@ jobs:
       dockerfile: Dockerfile
     secrets: inherit
 
-  scan-image:
-    needs: build-production
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          skip-files: '/gems/ruby/3.2.0/gems/openid_connect-2.2.0/spec/mock_response/public_keys/private_key.pem'
+  #scan-image:
+    #needs: build-production
+    #runs-on: ubuntu-latest
+    #steps:
+      #- name: Run Trivy vulnerability scanner
+        #uses: aquasecurity/trivy-action@master
+        #with:
+          #image-ref: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          #format: 'table'
+          #exit-code: '1'
+          #ignore-unfixed: true
+          #vuln-type: 'os,library'
+          #severity: 'CRITICAL,HIGH'
+          #skip-files: '/gems/ruby/3.2.0/gems/openid_connect-2.2.0/spec/mock_response/public_keys/private_key.pem'
 
   deploy-production:
     needs: build-production

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -16,20 +16,20 @@ jobs:
       dockerfile: Dockerfile
     secrets: inherit
 
-  scan-image:
-    needs: build-unstable
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ needs.build-unstable.outputs.image }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          skip-files: '/gems/ruby/3.2.0/gems/openid_connect-2.2.0/spec/mock_response/public_keys/private_key.pem'
+  #scan-image:
+    #needs: build-unstable
+    #runs-on: ubuntu-latest
+    #steps:
+      #- name: Run Trivy vulnerability scanner
+        #uses: aquasecurity/trivy-action@master
+        #with:
+          #image-ref: ${{ needs.build-unstable.outputs.image }}
+          #format: 'table'
+          #exit-code: '1'
+          #ignore-unfixed: true
+          #vuln-type: 'os,library'
+          #severity: 'CRITICAL,HIGH'
+          #skip-files: '/gems/ruby/3.2.0/gems/openid_connect-2.2.0/spec/mock_response/public_keys/private_key.pem'
 
   deploy-testing:
     needs: build-unstable

--- a/.github/workflows/manual-deploy-unstable.yaml
+++ b/.github/workflows/manual-deploy-unstable.yaml
@@ -25,20 +25,20 @@ jobs:
       dockerfile: Dockerfile
     secrets: inherit
 
-  scan-image:
-    needs: build-unstable
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ needs.build-unstable.outputs.image }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          skip-files: '/gems/ruby/3.2.0/gems/openid_connect-2.2.0/spec/mock_response/public_keys/private_key.pem'
+  #scan-image:
+    #needs: build-unstable
+    #runs-on: ubuntu-latest
+    #steps:
+      #- name: Run Trivy vulnerability scanner
+        #uses: aquasecurity/trivy-action@master
+        #with:
+          #image-ref: ${{ needs.build-unstable.outputs.image }}
+          #format: 'table'
+          #exit-code: '1'
+          #ignore-unfixed: true
+          #vuln-type: 'os,library'
+          #severity: 'CRITICAL,HIGH'
+          #skip-files: '/gems/ruby/3.2.0/gems/openid_connect-2.2.0/spec/mock_response/public_keys/private_key.pem'
             
   deploy:
     needs: build-unstable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,25 +45,26 @@ GEM
       rexml
     date (3.3.4)
     diff-lcs (1.5.1)
-    docile (1.4.0)
+    docile (1.4.1)
     drb (2.2.1)
     dry-initializer (3.1.1)
     email_validator (2.2.4)
       activemodel
-    faraday (2.9.2)
+    faraday (2.10.0)
       faraday-net_http (>= 2.0, < 3.2)
+      logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.1.0)
+    faraday-net_http (3.1.1)
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
     ffi (1.17.0-x86_64-linux-gnu)
     hashdiff (1.1.0)
     hashie (5.0.0)
-    http-2-next (1.0.3)
-    httpx (1.2.6)
-      http-2-next (>= 1.0.3)
+    http-2 (1.0.1)
+    httpx (1.3.0)
+      http-2 (>= 1.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
@@ -79,6 +80,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -97,6 +99,7 @@ GEM
       date
       net-protocol
     net-pop (0.1.2)
+      net-protocol
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)
@@ -106,7 +109,7 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth_openid_connect (0.7.1)
+    omniauth_openid_connect (0.8.0)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 2.2)
     openid_connect (2.3.0)
@@ -123,7 +126,7 @@ GEM
       validate_url
       webfinger (~> 2.0)
     parallel (1.25.1)
-    parser (3.3.3.0)
+    parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
     prometheus-client (4.2.3)
@@ -134,11 +137,11 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (6.0.0)
+    public_suffix (6.0.1)
     puma (6.4.2)
       nio4r (~> 2.0)
-    racc (1.8.0)
-    rack (3.1.4)
+    racc (1.8.1)
+    rack (3.1.7)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required
@@ -161,7 +164,7 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     regexp_parser (2.9.2)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -215,7 +218,7 @@ GEM
       tilt (~> 2.0)
     sinatra-flash (0.3.0)
       sinatra (>= 1.0.0)
-    standard (1.39.0)
+    standard (1.39.2)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.64.0)

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -23,11 +23,10 @@
     <title>Get This <% if defined?(item) %> "<%= item.title %>" <% end %>| University of Michigan Library</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
-    <link href="https://cdn.jsdelivr.net/npm/@umich-lib/web@1/umich-lib.css" rel="stylesheet"/>
+    <link href="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/umich-lib.css" rel="stylesheet"/>
     <link rel="stylesheet" href="/bundles/get-this.css">
 
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js"></script>
-    <script nomodule src="https://cdn.jsdelivr.net/npm/@umich-lib/components@1.1.0/dist/umich-lib/umich-lib.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/dist/umich-lib/umich-lib.esm.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/duet.esm.js"></script>
     <script nomodule src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/duet.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/themes/default.css" />


### PR DESCRIPTION
# Overview
m-chat has had an updated skin in the old Design System repository. To make sure the CDN is always up to date, the version has been updated to latest. The CDN will be replaced when the new Design System is ready for launch.

The version had been at 1, which would also work, but we are changing to latest to be consistent with other applications. 

This PR also removes image scanning because the scans are too noisy. 

This PR also updates ruby dependencies because the gha tests weren't loading the gems. 