### PR TITLE
hotfix: add openstruct

### DIFF
--- a/get-this.rb
+++ b/get-this.rb
@@ -7,6 +7,7 @@ require "omniauth"
 require "omniauth_openid_connect"
 require "sinatra/flash"
 require "faraday/follow_redirects"
+require "ostruct"
 
 Time.zone = "Eastern Time (US & Canada)"
 


### PR DESCRIPTION
# Overview

The `ostruct` package needs to be explicitly required. 