### PR TITLE
Add workflow for updating closed days configuration

### DIFF
--- a/.github/workflows/update-closed-days.yaml
+++ b/.github/workflows/update-closed-days.yaml
@@ -1,0 +1,33 @@
+name: Update Closed Days
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 8 1 * *' #8AM first of the month
+
+jobs:
+  update-closed-days:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create .env file
+        run: cat env.* > .env
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2.3.0
+      - name: Set up Ruby 3.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+        env: 
+          BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.GITHUB_TOKEN }}
+      - name: update closed days
+        env:
+          ALMA_API_KEY: $${{ secrets.ALMA_API_KEY }}
+        run: bundle exec ruby bin/update_alma_config.rb
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with: 
+          branch: update-closed-days
+          commit-message: "Update closed days"
+          title: "Update closed days" 
+          reviewers: niquerio, erinesullivan

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -62,6 +62,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with: 
+          branch: update-dependencies
           commit-message: "Update dependencies"
           title: ${{ env.PR_TITLE }}
           body-path: /tmp/pr_body.md


### PR DESCRIPTION
# Overview
There has been a script to update the list of closed days based on information in Alma, but it has had to be run manually. This PR adds a gha to check for updates monthly and if there are any creates a PR for the changes.

It also specifies a dedicated branch for the `update-dependencies` action, and sets a different branch for this one.