### PR TITLE
Omniauth to oauth2 proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,12 @@ gem "puma"
 gem "yabeda-puma-plugin"
 gem "yabeda-prometheus"
 gem "activesupport" # in here because of timezone support
-gem "omniauth"
-gem "omniauth_openid_connect"
 gem "sinatra-flash"
 gem "rackup"
 
 gem "alma_rest_client",
   git: "https://github.com/mlibrary/alma_rest_client",
-  tag: "v2.0.0"
+  tag: "alma_rest_client/v2.2.0"
 
 # In order to get rspec to work for ruby 3.3. Maybe later see if it's still necessary
 gem "net-smtp", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/mlibrary/alma_rest_client
-  revision: 9606225d82480b6d1568902813ae9018dd8c1acc
-  tag: v2.0.0
+  revision: f94276a6e83d1526f7ec91c66aad1cee8b80f97d
+  tag: alma_rest_client/v2.2.0
   specs:
-    alma_rest_client (2.0.0)
-      activesupport (~> 7.0, >= 4.2)
+    alma_rest_client (2.2.0)
+      activesupport (~> 8.0)
       faraday
       faraday-retry
       httpx
@@ -13,9 +13,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.2.2.1)
-      activesupport (= 7.2.2.1)
-    activesupport (7.2.2.1)
+    activesupport (8.0.2)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -27,17 +25,15 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    aes_key_wrap (1.1.0)
     anyway_config (2.7.2)
       ruby-next-core (~> 1.0)
     ast (2.4.3)
-    attr_required (1.0.2)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.1)
-    bindata (2.5.1)
     byebug (12.0.0)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -46,13 +42,10 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    date (3.4.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
     dry-initializer (3.2.0)
-    email_validator (2.2.4)
-      activemodel
     faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -65,69 +58,30 @@ GEM
       faraday (~> 2.0)
     ffi (1.17.2-x86_64-linux-gnu)
     hashdiff (1.2.0)
-    hashie (5.0.0)
     http-2 (1.1.1)
     httpx (1.5.0)
       http-2 (>= 1.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.12.2)
-    json-jwt (1.16.7)
-      activesupport (>= 4.2)
-      aes_key_wrap
-      base64
-      bindata
-      faraday (~> 2.0)
-      faraday-follow_redirects
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    mail (2.8.1)
-      mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     method_source (1.1.0)
-    mini_mime (1.1.5)
     minitest (5.25.5)
     multi_json (1.15.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     net-http (0.6.0)
       uri
-    net-imap (0.5.8)
-      date
-      net-protocol
-    net-pop (0.1.2)
-      net-protocol
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    omniauth (2.1.3)
-      hashie (>= 3.4.6)
-      rack (>= 2.2.3)
-      rack-protection
-    omniauth_openid_connect (0.8.0)
-      omniauth (>= 1.9, < 3)
-      openid_connect (~> 2.2)
-    openid_connect (2.3.1)
-      activemodel
-      attr_required (>= 1.0.0)
-      email_validator
-      faraday (~> 2.0)
-      faraday-follow_redirects
-      json-jwt (>= 1.16)
-      mail
-      rack-oauth2 (~> 2.2)
-      swd (~> 2.0)
-      tzinfo
-      validate_url
-      webfinger (~> 2.0)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -146,13 +100,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.15)
-    rack-oauth2 (2.2.1)
-      activesupport
-      attr_required
-      faraday (~> 2.0)
-      faraday-follow_redirects
-      json-jwt (>= 1.11.0)
-      rack (>= 2.1.0)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -238,11 +185,6 @@ GEM
     standard-performance (1.8.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
-    swd (2.0.3)
-      activesupport (>= 3)
-      attr_required (>= 0.0.5)
-      faraday (~> 2.0)
-      faraday-follow_redirects
     tilt (2.6.0)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -251,13 +193,6 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uri (1.0.3)
-    validate_url (1.0.15)
-      activemodel (>= 3.0.0)
-      public_suffix
-    webfinger (2.1.3)
-      activesupport
-      faraday (~> 2.0)
-      faraday-follow_redirects
     webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -285,8 +220,6 @@ DEPENDENCIES
   faraday-follow_redirects
   listen
   net-smtp
-  omniauth
-  omniauth_openid_connect
   pry
   pry-byebug
   puma

--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ docker compose up -d
 
 ## Updating `institution_hours_exceptions.json`
 
-`config/institution_hours_exceptions.json` is a static file that needs to be updated yearly.
+`config/institution_hours_exceptions.json` is a static file that needs to be
+updated yearly.
 
-### Steps
+There is a github action that checks monthly for updates and then creates a
+pull request. By merging that pull request and making a release this will stay
+up-to-date.
+
+### Manual Steps
 
 1. Verify that you are using a production Alma API Key.
 
@@ -38,6 +43,7 @@ docker compose up -d
 docker compose run --rm web ruby bin/update_alma_config.rb
 ```
 
-The file `config/institution_hours_exceptions.json` will get replaced with the latest information.
+The file `config/institution_hours_exceptions.json` will get replaced with the
+latest information.
 
 3. Commit the file and go through the app release process. 

--- a/env.example
+++ b/env.example
@@ -1,6 +1,4 @@
 ALMA_API_KEY='YOUR-ALMA-API-KEY'
-OIDC_CLIENT_SECRET='YOUR-OIDC-CLIENT-SECRET'
-OIDC_CLIENT_ID='YOUR-OIDC-CLIENT-ID'
-OIDC_ISSUER='https://your-oidc-issuer'
-WEBLOGIN_ON='false'
 ACCOUNT_URL='https://account.lib.umich.edu'
+APP_ENV='development'
+

--- a/get-this.rb
+++ b/get-this.rb
@@ -3,8 +3,6 @@ require "sinatra/reloader" if development?
 require "alma_rest_client"
 require "byebug" if development?
 require "active_support/all"
-require "omniauth"
-require "omniauth_openid_connect"
 require "sinatra/flash"
 require "faraday/follow_redirects"
 require "ostruct"

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -4,10 +4,10 @@ describe "requests" do
   before(:each) do
     @session = {
       uniqname: "tutor",
-      authenticated: true,
       expires_at: Time.now + 1.day
     }
     env "rack.session", @session
+    env "HTTP_X_AUTH_REQUEST_USER", "tutor"
   end
   context "/" do
     it "for a logged in user, redirects to 'Find, Borrow, Request'" do
@@ -23,8 +23,8 @@ describe "requests" do
   end
   context "/-/live" do
     it "works even for a not-logged-in user" do
-      @session[:authenticated] = false
-      env "rack.session", @session
+      env "rack.session", {}
+      env "HTTP_X_AUTH_REQUEST_USER", nil
       get "/-/live"
       expect(last_response.status).to eq(200)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,10 +22,9 @@ require "httpx/adapters/webmock"
 require "simplecov"
 require "climate_control"
 SimpleCov.start
-ENV["RACK_ENV"] = "test"
+ENV["APP_ENV"] = "test"
 
 require File.expand_path "../../get-this.rb", __FILE__
-OmniAuth.config.test_mode = true
 module RSpecMixin
   include Rack::Test::Methods
   include AlmaRestClient::Test::Helpers

--- a/spec/weblogin_spec.rb
+++ b/spec/weblogin_spec.rb
@@ -2,123 +2,52 @@ require "spec_helper"
 describe "requests" do
   include Rack::Test::Methods
   before(:each) do
-    @session = {
-      uniqname: "tutor",
-      authenticated: true,
-      expires_at: Time.now + 1.day
-    }
-    env "rack.session", @session
+    env "HTTP_X_AUTH_REQUEST_USER", "tutor"
   end
   let(:stub_item) { stub_alma_get_request(url: "items", output: fixture("item.json"), query: {item_barcode: "somebarcode", expand: "due_date"}) }
   let(:stub_patron) { stub_alma_get_request(url: "users/tutor", output: fixture("mrio_user_alma.json")) }
-  context "/login" do
-    it "sends off to omniauth; session has correct redirect path" do
-      stub_item
-      @session[:authenticated] = false
-      env "rack.session", @session
+
+  let(:stub_api_calls) do
+    stub_item
+    stub_patron
+  end
+
+  let(:expect_uniqname_in_session) do
+    session = last_request.env["rack.session"]
+    expect(session[:uniqname]).to eq("tutor")
+  end
+
+  context "empty X_AUTH header not found in alma" do
+    it "returns 401 response" do
+      env "HTTP_X_AUTH_REQUEST_USER", nil
       get "/somebarcode"
-      expect(last_request.env["rack.session"][:path_before_login]).to eq("/somebarcode")
-      expect(URI.parse(last_response.location).path).to eq("/login")
+      expect(last_response.status).to eq(401)
     end
   end
-  context "authenticated but expired" do
-    it "redirects to omniauth with correct redirect path" do
-      @session[:authenticated] = true
-      @session[:expires_at] = Time.now - 1.hour
-      env "rack.session", @session
+
+  context "uniqname in the header but there isn't a session" do
+    it "sets the session to the user in the header" do
+      env "rack.session", {}
+      stub_api_calls
       get "/somebarcode"
-      expect(last_request.env["rack.session"][:path_before_login]).to eq("/somebarcode")
-      expect(URI.parse(last_response.location).path).to eq("/login")
+      expect_uniqname_in_session
     end
   end
-  context "not authenticated" do
-    it "has nil uniqname for barcode page" do
-      stub_item
-      @session[:authenticated] = false
-      @session[:uniqname] = nil
-      env "rack.session", @session
+
+  context "session has a different patron than the header" do
+    it "sets the session to the user in the header" do
+      env "rack.session", {uniqname: "not_tutor"}
+      stub_api_calls
       get "/somebarcode"
-      expect(last_request.env["rack.session"][:uniqname]).to be_nil
+      expect_uniqname_in_session
     end
   end
-  context "authenticated" do
-    it "passes through with logged in info" do
-      stub_item
-      stub_patron
-      get "/somebarcode"
-      session = last_request.env["rack.session"]
-      expect(session[:uniqname]).to eq("tutor")
-      expect(session[:authenticated]).to eq(true)
-    end
-  end
-  context "get '/auth/openid_connect/callback'" do
-    let(:omniauth_auth) {
-      {
-        info: {nickname: "nottutor"},
-        credentials: {expires_in: 86399}
-      }
-    }
-    before(:each) do
-      stub_alma_get_request(url: "users/nottutor", status: 400)
-      OmniAuth.config.add_mock(:openid_connect, omniauth_auth)
-    end
-    it "sets session to appropriate values and redirects to home" do
-      get "/auth/openid_connect/callback"
-      session = last_request.env["rack.session"]
-      expect(session[:authenticated]).to eq(true)
-      expect(session[:uniqname]).to eq("nottutor")
-      expect(session[:expires_at]).to be <= (Time.now.utc + 1.hour)
-      expect(URI.parse(last_response.location).path).to eq("/")
-    end
-    it "redirects to location stored in the session" do
-      @session[:path_before_login] = "/somebarcode"
-      env "rack.session", @session
-      get "/auth/openid_connect/callback"
-      expect(last_request.env["rack.session"][:path_before_login]).to be_nil
-      expect(URI.parse(last_response.location).path).to eq("/somebarcode")
-    end
-  end
+
   context "/logout" do
     it "clears the session and redirects to shibboleth" do
       get "/logout"
       expect(last_request.env["rack.session"][:uniqname]).to be_nil
       expect(last_response.location).to eq("https://shibboleth.umich.edu/cgi-bin/logout?https://lib.umich.edu/")
     end
-  end
-  context "dev_login" do
-    it "shows dev login options when 'WEBLOGIN_ON' is false and in development environment" do
-      stub_item
-      stub_patron
-      app.settings.environment = :development
-      with_modified_env WEBLOGIN_ON: "false" do
-        get "/somebarcode"
-        expect(last_response.body).to include("Development Options")
-      end
-      # reset the environment
-      app.settings.environment = :test
-    end
-    it "doesn't show dev login options for 'WEBLOGIN_ON' is true even in development environment" do
-      stub_item
-      stub_patron
-      app.settings.environment = :development
-      with_modified_env WEBLOGIN_ON: "true" do
-        get "/somebarcode"
-        expect(last_response.body).not_to include("Development Options")
-      end
-      # reset the environment
-      app.settings.environment = :test
-    end
-    it "doesn't show dev login options for 'WEBLOGIN_ON' false but not in development environment" do
-      stub_item
-      stub_patron
-      expect(app.settings.environment).to eq(:test)
-      with_modified_env WEBLOGIN_ON: "false" do
-        get "/somebarcode"
-        expect(last_response.body).not_to include("Development Options")
-      end
-    end
-  end
-  def with_modified_env(options, &block)
-    ClimateControl.modify(options, &block)
   end
 end


### PR DESCRIPTION
This is change is parallel to the [one in Account](https://github.com/mlibrary/account/pull/344). 

It also updates `alma_rest_client` to the latest version.
