### PR TITLE
trying dependabot multi-ecosystem-group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+
+multi-ecosystem-groups:
+  app-dependencies:
+    schedule:
+      interval: "daily"
+      #time: "06:00"
+      #day: "monday"
+      timezone: "America/Detroit"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "Monthly dependency updates: "
+    open-pull-requests-limit: 5
+    reviewers:
+      - "erinesullivan"
+      - "mrio"
+
+
+updates:
+  # For npm/JavaScript dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    multi-ecosystem-group: "app-dependencies"
+    patterns: ["*"]
+
+  # For GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    multi-ecosystem-group: "app-dependencies"
+    patterns: ["*"]
+
+  # For Bundler/Ruby
+  - package-ecosystem: "bundler"
+    directory: "/"
+    multi-ecosystem-group: "app-dependencies"
+    patterns: ["*"]


### PR DESCRIPTION
We've been wanting to trying using dependabot for updates. It now has both grouping of PRs by package manager, and grouping multiple package managers into one PR.

This is a test on a daily interval to see what it makes.